### PR TITLE
Add CoLoR development version for 8.5, direct from upstream.

### DIFF
--- a/extra-dev/packages/coq:color/coq:color.1.0.0.dev/descr
+++ b/extra-dev/packages/coq:color/coq:color.1.0.0.dev/descr
@@ -1,0 +1,1 @@
+A library on rewriting theory and termination.

--- a/extra-dev/packages/coq:color/coq:color.1.0.0.dev/files/termslifting.patch
+++ b/extra-dev/packages/coq:color/coq:color.1.0.0.dev/files/termslifting.patch
@@ -1,0 +1,10 @@
+--- Term/SimpleType/TermsLiftingOrig.v	2015-05-14 14:01:01.000000000 +0200
++++ Term/SimpleType/TermsLifting.v	2015-05-14 14:01:11.000000000 +0200
+@@ -517,7 +517,6 @@
+     induction G; destruct x; try_solve.
+     destruct a; try_solve.
+     exists t; try_solve.
+-    inversion H; trivial.
+   Qed.
+ 
+   Lemma app_lift_app_aux : forall M (Mapp: isApp M) n k,

--- a/extra-dev/packages/coq:color/coq:color.1.0.0.dev/opam
+++ b/extra-dev/packages/coq:color/coq:color.1.0.0.dev/opam
@@ -3,8 +3,11 @@ author: "Frédéric Blanqui"
 maintainer: "frederic.blanqui@inria.fr"
 homepage: "http://color.inria.fr/"
 license: "CeCILL"
+patches: ["termslifting.patch"]
 build: [
-  [make "-j%{jobs}%"]
+[make "Makefile.coq"]
+[make "clean"]
+[make "-j%{jobs}%"]
 ]
 install: [
   [make "install"]

--- a/extra-dev/packages/coq:color/coq:color.1.0.0.dev/opam
+++ b/extra-dev/packages/coq:color/coq:color.1.0.0.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2" 
+author: "Frédéric Blanqui"
+maintainer: "frederic.blanqui@inria.fr"
+homepage: "http://color.inria.fr/"
+license: "CeCILL"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CoLoR"]
+depends: [
+  "coq" {= "8.5.dev"}
+]

--- a/extra-dev/packages/coq:color/coq:color.1.0.0.dev/opam
+++ b/extra-dev/packages/coq:color/coq:color.1.0.0.dev/opam
@@ -9,7 +9,7 @@ build: [
 [make "-j%{jobs}%"]
 ]
 install: [
-  [make "install"]
+  [make "-f" "Makefile.coq" "install"]
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CoLoR"]
 depends: [

--- a/extra-dev/packages/coq:color/coq:color.1.0.0.dev/opam
+++ b/extra-dev/packages/coq:color/coq:color.1.0.0.dev/opam
@@ -5,8 +5,7 @@ homepage: "http://color.inria.fr/"
 license: "CeCILL"
 patches: ["termslifting.patch"]
 build: [
-[make "Makefile.coq"]
-[make "clean"]
+["rm" "Util/Vector/NaryFunction.vo"]
 [make "-j%{jobs}%"]
 ]
 install: [

--- a/extra-dev/packages/coq:color/coq:color.1.0.0.dev/url
+++ b/extra-dev/packages/coq:color/coq:color.1.0.0.dev/url
@@ -1,0 +1,2 @@
+http: "http://color.inria.fr/color-coq8.5beta.tar.gz"
+checksum: "5f07636216dca13586fc73884ab1869e"

--- a/extra-dev/packages/coq:equations-fpred/coq:equations-fpred.1.0.1.dev/descr
+++ b/extra-dev/packages/coq:equations-fpred/coq:equations-fpred.1.0.1.dev/descr
@@ -1,0 +1,1 @@
+A formalization of Predicative System F, including a computable normalization function.

--- a/extra-dev/packages/coq:equations-fpred/coq:equations-fpred.1.0.1.dev/opam
+++ b/extra-dev/packages/coq:equations-fpred/coq:equations-fpred.1.0.1.dev/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2" 
+author: ["Matthieu Sozeau <matthieu.sozeau@inria.fr>" "Cyprien Mangin <cyprien.mangin@m4x.org>"]
+bug-reports: "mailto:matthieu.sozeau@inria.fr"
+dev-repo: "http://equations-fpred.gforge.inria.fr/"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "http://equations-fpred.gforge.inria.fr/"
+license: "CeCILL"
+build: [
+["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+[make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: [make "uninstall"]
+depends: [
+  "coq" {= "8.5.dev"}
+]

--- a/extra-dev/packages/coq:equations-fpred/coq:equations-fpred.1.0.1.dev/opam
+++ b/extra-dev/packages/coq:equations-fpred/coq:equations-fpred.1.0.1.dev/opam
@@ -4,7 +4,7 @@ bug-reports: "mailto:matthieu.sozeau@inria.fr"
 dev-repo: "http://equations-fpred.gforge.inria.fr/"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "http://equations-fpred.gforge.inria.fr/"
-license: "CeCILL"
+license: "LGPL"
 build: [
 ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
 [make "-j%{jobs}%"]
@@ -15,4 +15,6 @@ install: [
 remove: [make "uninstall"]
 depends: [
   "coq" {= "8.5.dev"}
+  "coq:equations" {= "8.5.dev"}
+  "coq:color" {= "1.0.0.dev"}
 ]

--- a/extra-dev/packages/coq:equations-fpred/coq:equations-fpred.1.0.1.dev/url
+++ b/extra-dev/packages/coq:equations-fpred/coq:equations-fpred.1.0.1.dev/url
@@ -1,0 +1,2 @@
+http: "http://equations-fpred.gforge.inria.fr/equations-fpred-1.0.1.tgz"
+checksum: "0b01d3fb26a961b117e1463f827e9078"


### PR DESCRIPTION
This compiles with the _current_ git version of 8.5 as of today.